### PR TITLE
Refactor wildcard handling

### DIFF
--- a/src/main/java/org/graylog/collector/file/FileObserver.java
+++ b/src/main/java/org/graylog/collector/file/FileObserver.java
@@ -82,7 +82,7 @@ public class FileObserver extends AbstractExecutionThreadService {
 
         @Override
         public String toString() {
-            return MoreObjects.toStringHelper(this).add("pathSet", pathSet.getPattern()).toString();
+            return MoreObjects.toStringHelper(this).add("pathSet", pathSet).toString();
         }
     }
 
@@ -97,7 +97,7 @@ public class FileObserver extends AbstractExecutionThreadService {
 
         final Path rootPath = pathSet.getRootPath();
 
-        log.debug("Watching directory {} for changes matching: {}", rootPath, pathSet.getPattern());
+        log.debug("Watching directory {} for changes matching: {}", rootPath, pathSet);
 
         final WatchKey key = rootPath.register(watcher, new WatchEvent.Kind[]{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY},
                 SensitivityWatchEventModifier.HIGH);

--- a/src/main/java/org/graylog/collector/file/FileReaderService.java
+++ b/src/main/java/org/graylog/collector/file/FileReaderService.java
@@ -99,8 +99,8 @@ public class FileReaderService extends AbstractService {
         }
 
         if (paths.isEmpty()) {
-            log.info("No files to follow for input \"{}\" yet, files will be followed once they appear in \"{}\"",
-                    input.getId(), pathSet.getRootPath());
+            log.info("Configured files for input \"{}\" do not exist yet. They will be followed once they are created.",
+                    input.getId());
         }
 
         for (Path path : paths) {

--- a/src/main/java/org/graylog/collector/file/FileReaderService.java
+++ b/src/main/java/org/graylog/collector/file/FileReaderService.java
@@ -98,6 +98,11 @@ public class FileReaderService extends AbstractService {
             return;
         }
 
+        if (paths.isEmpty()) {
+            log.info("No files to follow for input \"{}\" yet, files will be followed once they appear in \"{}\"",
+                    input.getId(), pathSet.getRootPath());
+        }
+
         for (Path path : paths) {
             if (!path.toFile().exists()) {
                 if (followMode) {

--- a/src/main/java/org/graylog/collector/file/GlobPathSet.java
+++ b/src/main/java/org/graylog/collector/file/GlobPathSet.java
@@ -1,0 +1,167 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.file;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class GlobPathSet implements PathSet {
+    private static final Logger LOG = LoggerFactory.getLogger(GlobPathSet.class);
+
+    private final String pattern;
+    private final FileTreeWalker fileTreeWalker;
+    private final PathMatcher matcher;
+    private final Path rootPath;
+
+    public static class GlobbingFileVisitor extends SimpleFileVisitor<Path> {
+        private final PathMatcher matcher;
+        private final ImmutableSet.Builder<Path> matchedPaths;
+
+        public GlobbingFileVisitor(PathMatcher matcher, ImmutableSet.Builder<Path> matchedPaths) {
+            this.matcher = matcher;
+            this.matchedPaths = matchedPaths;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+            // Skip /proc because it can throw some permission errors we cannot check for.
+            return dir.toString().startsWith("/proc") ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+            LOG.warn("Unable to change into directory {} - Check permissions", file);
+            return FileVisitResult.SKIP_SUBTREE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+            if (matcher.matches(file)) {
+                // TODO needs to be an absolute path because otherwise the FileObserver does weird things. Investigate what's wrong with it.
+                matchedPaths.add(file.toAbsolutePath());
+            }
+
+            return FileVisitResult.CONTINUE;
+        }
+    }
+
+    public interface FileTreeWalker {
+        void walk(Path basePath, FileVisitor<Path> visitor) throws IOException;
+    }
+
+    public GlobPathSet(final String rootPathString, final String pattern) {
+        this(rootPathString, pattern, new FileTreeWalker() {
+            @Override
+            public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
+                Files.walkFileTree(basePath, visitor);
+            }
+        });
+    }
+
+    public GlobPathSet(final String rootPathString, final String pattern, final FileTreeWalker fileTreeWalker) {
+        this(rootPathString, pattern, fileTreeWalker, FileSystems.getDefault());
+    }
+
+    public GlobPathSet(final String rootPathString, final String pattern, final FileTreeWalker fileTreeWalker, final FileSystem fileSystem) {
+        this.rootPath = fileSystem.getPath(checkNotNull(rootPathString)).toAbsolutePath();
+        this.pattern = pattern;
+        this.fileTreeWalker = fileTreeWalker;
+        this.matcher = fileSystem.getPathMatcher(buildGlobPattern(fileSystem, rootPath, pattern));
+    }
+
+    private static String buildGlobPattern(final FileSystem fileSystem, final Path rootPath, final String pattern) {
+        final String rootPathString;
+
+        if (!rootPath.toString().endsWith(fileSystem.getSeparator())) {
+            rootPathString = rootPath.toString() + fileSystem.getSeparator();
+        } else {
+            rootPathString = rootPath.toString();
+        }
+
+        // Escape special backslash character in root path.
+        return "glob:" + rootPathString.replace("\\", "\\\\") + pattern;
+    }
+
+    @Override
+    public Path getRootPath() {
+        return rootPath;
+    }
+
+    @Override
+    public boolean isInSet(Path path) {
+        return matcher.matches(path);
+    }
+
+    /**
+     * Returns a {@link Set<Path>} of all existing paths that match the pattern.
+     *
+     * The file tree is walked on every invocation to pick up newly created paths. This can be expensive!
+     *
+     * @return all existing paths that match the pattern
+     * @throws IOException
+     */
+    @Override
+    public Set<Path> getPaths() throws IOException {
+        final ImmutableSet.Builder<Path> matchedPaths = ImmutableSet.builder();
+
+        fileTreeWalker.walk(rootPath, new GlobbingFileVisitor(matcher, matchedPaths));
+
+        return matchedPaths.build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GlobPathSet that = (GlobPathSet) o;
+
+        return pattern.equals(that.pattern) && rootPath.equals(that.rootPath);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pattern.hashCode();
+        result = 31 * result + rootPath.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("rootPath", rootPath)
+                .add("pattern", pattern)
+                .toString();
+    }
+}

--- a/src/main/java/org/graylog/collector/file/GlobPathSet.java
+++ b/src/main/java/org/graylog/collector/file/GlobPathSet.java
@@ -55,7 +55,7 @@ public class GlobPathSet implements PathSet {
         @Override
         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
             // Skip /proc because it can throw some permission errors we cannot check for.
-            return dir.toString().startsWith("/proc") ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
+            return "/proc".equals(dir.toString()) ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
         }
 
         @Override

--- a/src/main/java/org/graylog/collector/file/PathSet.java
+++ b/src/main/java/org/graylog/collector/file/PathSet.java
@@ -16,188 +16,30 @@
  */
 package org.graylog.collector.file;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import org.graylog.collector.utils.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.List;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-public class PathSet {
-    private static final Logger LOG = LoggerFactory.getLogger(PathSet.class);
-
-    // List taken from sun.nio.fs.Globs.
-    private static final List<String> GLOB_META_CHARS = ImmutableList.of("\\", "*", "?", "[", "{");
-
-    private final String pattern;
-    private final FileTreeWalker fileTreeWalker;
-    private final FileSystem fileSystem;
-    private final PathMatcher matcher;
-    private final Path rootPath;
-
-    public static class GlobbingFileVisitor extends SimpleFileVisitor<Path> {
-        private final PathMatcher matcher;
-        private final ImmutableSet.Builder<Path> matchedPaths;
-
-        public GlobbingFileVisitor(PathMatcher matcher, ImmutableSet.Builder<Path> matchedPaths) {
-            this.matcher = matcher;
-            this.matchedPaths = matchedPaths;
-        }
-
-        @Override
-        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-            // Skip /proc because it can throw some permission errors we cannot check for.
-            return dir.startsWith("/proc") ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-            LOG.warn("Unable to change into directory {} - Check permissions", file);
-            return FileVisitResult.SKIP_SUBTREE;
-        }
-
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
-            if (matcher.matches(file)) {
-                // TODO needs to be an absolute path because otherwise the FileObserver does weird things. Investigate what's wrong with it.
-                matchedPaths.add(file.toAbsolutePath());
-            }
-
-            return FileVisitResult.CONTINUE;
-        }
-    }
-
-    public interface FileTreeWalker {
-        void walk(Path basePath, FileVisitor<Path> visitor) throws IOException;
-    }
-
+public interface PathSet {
     /**
-     * Default FileTrackingList that uses the file system to scan for files to track.
-     *
-     * @param pattern the pattern to scan for
+     * Get the root path of the path set.
+     * @return the root path
      */
-    public PathSet(final String pattern) {
-        this(pattern, new FileTreeWalker() {
-            @Override
-            public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
-                Files.walkFileTree(basePath, visitor);
-            }
-        });
-    }
-
-    public PathSet(final String pattern, final FileTreeWalker fileTreeWalker) {
-        this(pattern, fileTreeWalker, FileSystems.getDefault());
-    }
-
-    public PathSet(final String pattern, final FileTreeWalker fileTreeWalker, final FileSystem fileSystem) {
-        this.pattern = checkNotNull(pattern);
-        this.fileTreeWalker = fileTreeWalker;
-        this.fileSystem = fileSystem;
-        final String patternString = Utils.isWindows() ? pattern.replace("\\", "\\\\") : pattern;
-        this.matcher = fileSystem.getPathMatcher("glob:" + patternString);
-        this.rootPath = getRootPathFromPattern(pattern);
-    }
-
-    public Path getRootPath() {
-        return rootPath;
-    }
-
-    public String getPattern() {
-        return pattern;
-    }
-
-    public boolean isInSet(Path path) {
-        return matcher.matches(path);
-    }
+    Path getRootPath();
 
     /**
-     * Returns a {@link Set<Path>} of all existing paths that match the pattern.
+     *  Checks if the given path is in the path set.
      *
-     * The file tree is walked on every invocation to pick up newly created paths. This can be expensive!
+     * @param path
+     * @return true if given path is in the path set, false otherwise
+     */
+    boolean isInSet(Path path);
+
+    /**
+     * Returns all files of the path set that exist in the file system.
      *
-     * @return all existing paths that match the pattern
+     * @return existing path set files in the file system
      * @throws IOException
      */
-    public Set<Path> getPaths() throws IOException {
-        final ImmutableSet.Builder<Path> matchedPaths = ImmutableSet.builder();
-
-        if (hasGlobMetaChars(pattern)) {
-            fileTreeWalker.walk(rootPath, new GlobbingFileVisitor(matcher, matchedPaths));
-        } else {
-            // TODO needs to be an absolute path because otherwise the FileObserver does weird things. Investigate what's wrong with it.
-            matchedPaths.add(fileSystem.getPath(pattern).toAbsolutePath());
-        }
-
-        return matchedPaths.build();
-    }
-
-    private Path getRootPathFromPattern(String pattern) {
-        if (!hasGlobMetaChars(pattern)) {
-            return fileSystem.getPath(pattern).toAbsolutePath().getParent();
-        }
-
-        final List<String> elements = Lists.newArrayList();
-
-        // Splitting manually on File.separator here to make it work on Windows.
-        for (String part : Splitter.on(File.separator).split(pattern)) {
-            if (hasGlobMetaChars(part)) {
-                break;
-            }
-
-            elements.add(part);
-        }
-
-        if (Utils.isWindows()) {
-            return fileSystem.getPath("", elements.toArray(new String[elements.size()]));
-        } else {
-            return fileSystem.getPath("/", elements.toArray(new String[elements.size()]));
-        }
-
-    }
-
-    private boolean hasGlobMetaChars(String path) {
-        if (path == null) {
-            return false;
-        }
-        for (String globMetaChar : GLOB_META_CHARS) {
-            if (path.contains(globMetaChar)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        PathSet pathSet = (PathSet) o;
-
-        return pattern.equals(pathSet.pattern);
-
-    }
-
-    @Override
-    public int hashCode() {
-        return pattern.hashCode();
-    }
-
+    Set<Path> getPaths() throws IOException;
 }

--- a/src/main/java/org/graylog/collector/file/SinglePathSet.java
+++ b/src/main/java/org/graylog/collector/file/SinglePathSet.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.file;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SinglePathSet implements PathSet {
+    private final Path path;
+
+    public SinglePathSet(final String path) {
+        this(path, FileSystems.getDefault());
+    }
+
+    public SinglePathSet(final String path, final FileSystem fileSystem) {
+        this.path = fileSystem.getPath(checkNotNull(path)).toAbsolutePath();
+    }
+
+    @Override
+    public Path getRootPath() {
+        return path.getParent();
+    }
+
+    @Override
+    public boolean isInSet(Path path) {
+        return path != null && this.path.equals(path.toAbsolutePath());
+    }
+
+    @Override
+    public Set<Path> getPaths() throws IOException {
+        return Files.exists(path) ? ImmutableSet.of(path) : ImmutableSet.<Path>of();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SinglePathSet that = (SinglePathSet) o;
+
+        return path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return path.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("path", path).toString();
+    }
+}

--- a/src/main/java/org/graylog/collector/file/SinglePathSet.java
+++ b/src/main/java/org/graylog/collector/file/SinglePathSet.java
@@ -24,6 +24,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -51,7 +52,7 @@ public class SinglePathSet implements PathSet {
 
     @Override
     public Set<Path> getPaths() throws IOException {
-        return Files.exists(path) ? ImmutableSet.of(path) : ImmutableSet.<Path>of();
+        return Files.exists(path) ? ImmutableSet.of(path) : Collections.<Path>emptySet();
     }
 
     @Override

--- a/src/main/java/org/graylog/collector/inputs/file/FileInputConfiguration.java
+++ b/src/main/java/org/graylog/collector/inputs/file/FileInputConfiguration.java
@@ -20,7 +20,9 @@ import com.google.inject.assistedinject.Assisted;
 import com.typesafe.config.Config;
 import org.graylog.collector.config.ConfigurationUtils;
 import org.graylog.collector.config.constraints.IsOneOf;
+import org.graylog.collector.file.GlobPathSet;
 import org.graylog.collector.file.PathSet;
+import org.graylog.collector.file.SinglePathSet;
 import org.graylog.collector.file.splitters.ContentSplitter;
 import org.graylog.collector.file.splitters.NewlineChunkSplitter;
 import org.graylog.collector.file.splitters.PatternChunkSplitter;
@@ -69,9 +71,14 @@ public class FileInputConfiguration extends InputConfiguration {
         super(id, config);
         this.inputFactory = inputFactory;
 
-        if (config.hasPath("path")) {
-            this.path = new PathSet(config.getString("path"));
+        if (config.hasPath("path-glob-root") && config.hasPath("path-glob-pattern")) {
+            this.path = new GlobPathSet(config.getString("path-glob-root"), config.getString("path-glob-pattern"));
+        } else {
+            if (config.hasPath("path")) {
+                this.path = new SinglePathSet(config.getString("path"));
+            }
         }
+
         if (config.hasPath("content-splitter")) {
             this.contentSplitter = config.getString("content-splitter").toUpperCase();
 

--- a/src/test/java/org/graylog/collector/file/FileObserverTest.java
+++ b/src/test/java/org/graylog/collector/file/FileObserverTest.java
@@ -53,7 +53,7 @@ public class FileObserverTest {
 
     @Test
     public void testObserverCallbacks() throws Exception {
-        final PathSet pathSet = new PathSet(temporaryFolder.getRoot().toString() + "/*");
+        final PathSet pathSet = new GlobPathSet(temporaryFolder.getRoot().toString(), "*");
         final FileObserver fileObserver = new FileObserver(watchService);
         final File file = temporaryFolder.newFile();
         final Path path = file.toPath();
@@ -121,8 +121,8 @@ public class FileObserverTest {
         final File file1 = temporaryFolder.newFile();
         final File file2 = temporaryFolder.newFile();
         final File file3 = temporaryFolder2.newFile();
-        final PathSet pathSet1 = new PathSet(temporaryFolder.getRoot().toString() + "/*");
-        final PathSet pathSet2 = new PathSet(temporaryFolder2.getRoot().toString() + "/*");
+        final GlobPathSet pathSet1 = new GlobPathSet(temporaryFolder.getRoot().toString(), "*");
+        final GlobPathSet pathSet2 = new GlobPathSet(temporaryFolder2.getRoot().toString(), "*");
         final Path path1 = file1.toPath();
         final Path path2 = file2.toPath();
         final Path path3 = file3.toPath();
@@ -235,7 +235,7 @@ public class FileObserverTest {
     @Test
     @Ignore("File naming strategies have been disabled for now")
     public void testNamingStrategy() throws Exception {
-        final PathSet pathSet = new PathSet(temporaryFolder.getRoot().toString() + "/*");
+        final GlobPathSet pathSet = new GlobPathSet(temporaryFolder.getRoot().toString(), "*");
         final FileObserver fileObserver = new FileObserver(watchService);
         final File file1 = temporaryFolder.newFile();
         final File file2 = temporaryFolder.newFile();

--- a/src/test/java/org/graylog/collector/file/FileReaderServiceTest.java
+++ b/src/test/java/org/graylog/collector/file/FileReaderServiceTest.java
@@ -82,7 +82,7 @@ public class FileReaderServiceTest extends MultithreadedBaseTest {
 
         final FileObserver fileObserverSpy = spy(fileObserver);
         final NumberSuffixStrategy namingStrategy = new NumberSuffixStrategy(path);
-        final PathSet pathSet = new PathSet(path.toString());
+        final PathSet pathSet = new SinglePathSet(path.toString());
 
         final FileReaderService readerService = new FileReaderService(
                 pathSet,
@@ -126,7 +126,7 @@ public class FileReaderServiceTest extends MultithreadedBaseTest {
         final CollectingBuffer buffer = new CollectingBuffer();
         final MessageBuilder messageBuilder = new MessageBuilder().input("input-id").outputs(new HashSet<String>()).source("test");
         final FileReaderService readerService = new FileReaderService(
-                new PathSet(path.toString()),
+                new SinglePathSet(path.toString()),
                 Charsets.UTF_8,
                 true,
                 FileInput.InitialReadPosition.START,
@@ -168,7 +168,7 @@ public class FileReaderServiceTest extends MultithreadedBaseTest {
         final CollectingBuffer buffer = new CollectingBuffer();
         final MessageBuilder messageBuilder = new MessageBuilder().input("input-id").outputs(new HashSet<String>()).source("test");
         final FileReaderService readerService = new FileReaderService(
-                new PathSet(path.toString()),
+                new SinglePathSet(path.toString()),
                 Charsets.UTF_8,
                 true,
                 FileInput.InitialReadPosition.START,
@@ -218,7 +218,7 @@ public class FileReaderServiceTest extends MultithreadedBaseTest {
         log.info("FILE 2 - {}", path2);
         log.info("FILE 3 - {}", path3);
 
-        final PathSet pathSet = new PathSet(temporaryFolder.getRoot().toString() + "/*");
+        final GlobPathSet pathSet = new GlobPathSet(temporaryFolder.getRoot().toString(), "*");
 
         // Delete the second file before starting.
         Files.deleteIfExists(path2);

--- a/src/test/java/org/graylog/collector/file/PathSetTest.java
+++ b/src/test/java/org/graylog/collector/file/PathSetTest.java
@@ -36,6 +36,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class PathSetTest {
+    public static final PathSet.FileTreeWalker NOOP_FILE_TREE_WALKER = new PathSet.FileTreeWalker() {
+        @Override
+        public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
+        }
+    };
+
     @Mock
     BasicFileAttributes attributes;
 
@@ -50,13 +56,14 @@ public class PathSetTest {
     private FileSystem newUnixFileSystem() {
         return Jimfs.newFileSystem(Configuration.unix());
     }
+
+    private FileSystem newWindowsFileSystem() {
+        return Jimfs.newFileSystem(Configuration.windows());
+    }
+
     @Test
     public void testTrackingList() throws Exception {
-        final PathSet list = new PathSet("/var/log/syslog", new PathSet.FileTreeWalker() {
-            @Override
-            public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
-            }
-        }, fileSystem);
+        final PathSet list = new PathSet("/var/log/syslog", NOOP_FILE_TREE_WALKER, fileSystem);
 
         final Set<Path> paths = list.getPaths();
 
@@ -112,11 +119,7 @@ public class PathSetTest {
 
     @Test
     public void testIsInSet() throws Exception {
-        final PathSet pathSet = new PathSet("/var/log/**/*.{log,gz}", new PathSet.FileTreeWalker() {
-            @Override
-            public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
-            }
-        }, fileSystem);
+        final PathSet pathSet = new PathSet("/var/log/**/*.{log,gz}", NOOP_FILE_TREE_WALKER, fileSystem);
 
         assertFalse(pathSet.isInSet(fileSystem.getPath("/var/log/mail.log")));
         assertTrue(pathSet.isInSet(fileSystem.getPath("/var/log/upstart/test.log")));
@@ -126,11 +129,7 @@ public class PathSetTest {
 
     @Test
     public void testIsInSetWithoutPattern() throws Exception {
-        final PathSet pathSet = new PathSet("/var/log/syslog", new PathSet.FileTreeWalker() {
-            @Override
-            public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
-            }
-        }, fileSystem);
+        final PathSet pathSet = new PathSet("/var/log/syslog", NOOP_FILE_TREE_WALKER, fileSystem);
 
         assertFalse(pathSet.isInSet(fileSystem.getPath("/var/log/mail.log")));
         assertTrue(pathSet.isInSet(fileSystem.getPath("/var/log/syslog")));
@@ -138,11 +137,7 @@ public class PathSetTest {
 
     @Test
     public void testEquality() throws Exception{
-        final PathSet.FileTreeWalker treeWalker = new PathSet.FileTreeWalker() {
-            @Override
-            public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
-            }
-        };
+        final PathSet.FileTreeWalker treeWalker = NOOP_FILE_TREE_WALKER;
 
         final PathSet pathSet1 = new PathSet("/var/log/syslog", treeWalker, fileSystem);
         final PathSet pathSet2 = new PathSet("/var/log/syslog", treeWalker, fileSystem);
@@ -156,11 +151,7 @@ public class PathSetTest {
 
     @Test
     public void testGetPattern() throws Exception {
-        final PathSet.FileTreeWalker treeWalker = new PathSet.FileTreeWalker() {
-            @Override
-            public void walk(Path basePath, FileVisitor<Path> visitor) throws IOException {
-            }
-        };
+        final PathSet.FileTreeWalker treeWalker = NOOP_FILE_TREE_WALKER;
 
         final PathSet pathSet1 = new PathSet("/var/log/syslog", treeWalker, fileSystem);
         final PathSet pathSet2 = new PathSet("/var/log/**/*.log", treeWalker, fileSystem);

--- a/src/test/java/org/graylog/collector/file/PathSetTest.java
+++ b/src/test/java/org/graylog/collector/file/PathSetTest.java
@@ -26,6 +26,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitor;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Set;
@@ -63,11 +64,14 @@ public class PathSetTest {
 
     @Test
     public void testTrackingList() throws Exception {
-        final PathSet list = new PathSet("/var/log/syslog", NOOP_FILE_TREE_WALKER, fileSystem);
+        final Path path = fileSystem.getPath("/var/log");
 
+        Files.createDirectories(path);
+
+        final PathSet list = new PathSet("/var/log/syslog", NOOP_FILE_TREE_WALKER, fileSystem);
         final Set<Path> paths = list.getPaths();
 
-        assertEquals(fileSystem.getPath("/var/log"), list.getRootPath());
+        assertEquals(path, list.getRootPath());
         assertEquals(1, paths.size());
         assertTrue(paths.contains(fileSystem.getPath("/var/log/syslog")));
     }
@@ -78,6 +82,11 @@ public class PathSetTest {
         final String file2 = "/var/log/test/compressed.log.1.gz";
         final String file3 = "/var/log/foo/bar/baz/test.log";
         final String file4 = "/var/log/test.log";
+
+        Files.createDirectories(fileSystem.getPath(file1).getParent());
+        Files.createDirectories(fileSystem.getPath(file2).getParent());
+        Files.createDirectories(fileSystem.getPath(file3).getParent());
+        Files.createDirectories(fileSystem.getPath(file4).getParent());
 
         final PathSet list = new PathSet("/var/log/**/*.{log,gz}", new PathSet.FileTreeWalker() {
             @Override
@@ -102,6 +111,8 @@ public class PathSetTest {
     @Test
     public void testTrackingListWithGlobEdgeCases() throws Exception {
         final String file1 = "/var/log/ups?art/graylog-collector.log";
+
+        Files.createDirectories(fileSystem.getPath(file1).getParent());
 
         final PathSet list = new PathSet("/var/log/ups\\?art/*.{log,gz}", new PathSet.FileTreeWalker() {
             @Override

--- a/src/test/java/org/graylog/collector/file/SinglePathSetTest.java
+++ b/src/test/java/org/graylog/collector/file/SinglePathSetTest.java
@@ -1,0 +1,82 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.file;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SinglePathSetTest {
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    private FileSystem newUnixFileSystem() {
+        return Jimfs.newFileSystem(Configuration.unix());
+    }
+
+    private FileSystem newWindowsFileSystem() {
+        return Jimfs.newFileSystem(Configuration.windows());
+    }
+
+    @Test
+    public void testUnix() throws Exception {
+        final FileSystem fileSystem = newUnixFileSystem();
+        final Path path = fileSystem.getPath("/var/log/syslog");
+        final PathSet pathSet = new SinglePathSet(path.toString(), fileSystem);
+
+        assertEquals(path.getParent(), pathSet.getRootPath());
+        assertTrue(pathSet.isInSet(path));
+        assertTrue("Path list should be empty without any files in the file system",
+                pathSet.getPaths().isEmpty());
+
+        Files.createDirectories(path.getParent());
+        Files.createFile(path);
+
+        assertEquals("Path list should not be empty after creating the file",
+                ImmutableSet.of(path), pathSet.getPaths());
+    }
+
+    @Test
+    public void testWindows() throws Exception {
+        final FileSystem fileSystem = newWindowsFileSystem();
+        final Path path = fileSystem.getPath("C:\\logs\\application.log");
+        final PathSet pathSet = new SinglePathSet(path.toString(), fileSystem);
+
+        assertEquals(path.getParent(), pathSet.getRootPath());
+        assertTrue(pathSet.isInSet(path));
+        assertTrue("Path list should be empty without any files in the file system",
+                pathSet.getPaths().isEmpty());
+
+        Files.createDirectories(path.getParent());
+        Files.createFile(path);
+
+        assertEquals("Path list should not be empty after creating the file",
+                ImmutableSet.of(path), pathSet.getPaths());
+    }
+}


### PR DESCRIPTION
- Create two PathSet types, one for globbing, one for a single path
  without globbing.
- Add "path-glob-root" and "path-glob-pattern" config options for the
  FileInput to handle the globbing case.
  The old "path" option is used when no globbing is needed.

Splitting the configuration options for globbing simplifies the implementation and makes it work on windows. Before this, we tried to detect the root path part and the pattern part of the configured file input path automatically which didn't work in all cases.
