### PR TITLE
Add protocol selector for GELF output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Graylog Collector ChangeLog
 ===========================
 
+## v0.5.0 (unreleased)
+
+* Add UDP support to GELF output. (#59)
+
 ## v0.4.2 (2016-01-04)
 
 * Fix concurrency issue in MessageBuilder/MessageFields.

--- a/config/collector.conf.example
+++ b/config/collector.conf.example
@@ -57,6 +57,17 @@ collector-id = "file:config/collector-id"
 //    client-send-buffer-size = 32768
 //  }
 //
+//  // GELF output to send messages to a Graylog server using UDP.
+//  // NOTE: GELF via UDP *does not* support TLS, so the connection will be unencrypted!
+//  gelf-udp {
+//    type = "gelf"
+//    protocol = "UDP"
+//    host = "127.0.0.1"
+//    port = 12201
+//    client-queue-size = 512
+//    client-send-buffer-size = 32768
+//  }
+//
 //  // Prints all messages to STDOUT. Useful for debugging. Do not enable in production usage!
 //  console {
 //    type = "stdout"

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.graylog</groupId>
     <artifactId>graylog-collector</artifactId>
-    <version>0.4.3-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <description>The Graylog Collector</description>
     <organization>
         <name>Graylog, Inc.</name>

--- a/src/main/java/org/graylog/collector/outputs/gelf/GelfOutput.java
+++ b/src/main/java/org/graylog/collector/outputs/gelf/GelfOutput.java
@@ -52,23 +52,34 @@ public class GelfOutput extends OutputService {
 
     @Override
     protected void doStart() {
-        final GelfConfiguration clientConfig = new GelfConfiguration(configuration.getHost(), configuration.getPort())
-                .transport(GelfTransports.TCP)
-                .queueSize(configuration.getClientQueueSize())
-                .connectTimeout(configuration.getClientConnectTimeout())
-                .reconnectDelay(configuration.getClientReconnectDelay())
-                .tcpNoDelay(configuration.isClientTcpNoDelay())
-                .sendBufferSize(configuration.getClientSendBufferSize());
+        final GelfConfiguration clientConfig = new GelfConfiguration(configuration.getHost(), configuration.getPort());
 
-        if (configuration.isClientTls()) {
-            clientConfig.enableTls();
-            clientConfig.tlsTrustCertChainFile(configuration.getClientTlsCertChainFile());
+        switch (configuration.getProtocol()) {
+            case UDP:
+                clientConfig
+                        .transport(GelfTransports.UDP)
+                        .queueSize(configuration.getClientQueueSize())
+                        .sendBufferSize(configuration.getClientSendBufferSize());
+            case TCP:
+                clientConfig
+                        .transport(GelfTransports.TCP)
+                        .queueSize(configuration.getClientQueueSize())
+                        .connectTimeout(configuration.getClientConnectTimeout())
+                        .reconnectDelay(configuration.getClientReconnectDelay())
+                        .tcpNoDelay(configuration.isClientTcpNoDelay())
+                        .sendBufferSize(configuration.getClientSendBufferSize());
 
-            if (configuration.isClientTlsVerifyCert()) {
-                clientConfig.enableTlsCertVerification();
-            } else {
-                clientConfig.disableTlsCertVerification();
-            }
+                if (configuration.isClientTls()) {
+                    clientConfig.enableTls();
+                    clientConfig.tlsTrustCertChainFile(configuration.getClientTlsCertChainFile());
+
+                    if (configuration.isClientTlsVerifyCert()) {
+                        clientConfig.enableTlsCertVerification();
+                    } else {
+                        clientConfig.disableTlsCertVerification();
+                    }
+                }
+                break;
         }
 
         LOG.info("Starting GELF transport: {}", clientConfig);

--- a/src/main/java/org/graylog/collector/outputs/gelf/GelfOutputConfiguration.java
+++ b/src/main/java/org/graylog/collector/outputs/gelf/GelfOutputConfiguration.java
@@ -20,6 +20,7 @@ import com.google.inject.assistedinject.Assisted;
 import com.typesafe.config.Config;
 import org.graylog.collector.config.ConfigurationUtils;
 import org.graylog.collector.outputs.OutputConfiguration;
+import org.graylog2.gelfclient.GelfTransports;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.Range;
 
@@ -28,6 +29,7 @@ import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class GelfOutputConfiguration extends OutputConfiguration {
@@ -37,6 +39,9 @@ public class GelfOutputConfiguration extends OutputConfiguration {
         @Override
         GelfOutputConfiguration create(String id, Config config);
     }
+
+    @NotNull
+    private GelfTransports protocol = GelfTransports.TCP;
 
     @NotBlank
     private String host;
@@ -79,6 +84,17 @@ public class GelfOutputConfiguration extends OutputConfiguration {
         super(id, config);
         this.outputFactory = outputFactory;
 
+        if (config.hasPath("protocol")) {
+            switch (config.getString("protocol").toUpperCase(Locale.ENGLISH)) {
+                case "UDP":
+                    this.protocol = GelfTransports.UDP;
+                    break;
+                case "TCP":
+                default:
+                    this.protocol = GelfTransports.TCP;
+                    break;
+            }
+        }
         if (config.hasPath("host")) {
             this.host = config.getString("host");
         }
@@ -114,6 +130,10 @@ public class GelfOutputConfiguration extends OutputConfiguration {
     @Override
     public GelfOutput createOutput() {
         return outputFactory.create(this);
+    }
+
+    public GelfTransports getProtocol() {
+        return protocol;
     }
 
     public String getHost() {


### PR DESCRIPTION
This PR adds the "protocol" configuration setting for the GELF output which allows sending messages to a Graylog Server using GELF via UDP.

Closes #59
