### PR TITLE
Use canonical host name as message source in WindowsEventlogInput

### DIFF
--- a/config/collector.conf.example
+++ b/config/collector.conf.example
@@ -13,6 +13,9 @@ server-url = "http://localhost:12900"
 // Defaults to "file:config/collector-id" if not specified.
 collector-id = "file:config/collector-id"
 
+// Override the detected local host name and send a custom host name
+//host-name = "my-custom-host-name"
+
 //inputs {
 //  // A simple file input that follows /var/log/syslog.
 //  local-syslog {

--- a/src/main/java/org/graylog/collector/annotations/CollectorHostName.java
+++ b/src/main/java/org/graylog/collector/annotations/CollectorHostName.java
@@ -14,14 +14,17 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog.collector.utils;
+package org.graylog.collector.annotations;
 
-import java.util.Locale;
+import com.google.inject.BindingAnnotation;
 
-public class Utils {
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.US).startsWith("windows");
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    public static boolean isWindows() {
-        return IS_WINDOWS;
-    }
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@BindingAnnotation
+public @interface CollectorHostName {
 }

--- a/src/main/java/org/graylog/collector/cli/commands/Run.java
+++ b/src/main/java/org/graylog/collector/cli/commands/Run.java
@@ -34,6 +34,7 @@ import org.graylog.collector.outputs.OutputsModule;
 import org.graylog.collector.serverapi.ServerApiModule;
 import org.graylog.collector.services.CollectorServiceManager;
 import org.graylog.collector.services.ServicesModule;
+import org.graylog.collector.utils.CollectorHostNameModule;
 import org.graylog.collector.utils.CollectorIdModule;
 import org.graylog.collector.utils.MemoryReporterModule;
 import org.jsoftbiz.utils.OS;
@@ -103,7 +104,8 @@ public class Run implements CollectorCommand {
                     new MemoryReporterModule(),
                     new ServerApiModule(),
                     new HeartbeatModule(),
-                    new CollectorIdModule());
+                    new CollectorIdModule(),
+                    new CollectorHostNameModule());
         } catch (Exception e) {
             LOG.error("ERROR: {}", e.getMessage());
             LOG.debug("Detailed injection creation error", e);

--- a/src/main/java/org/graylog/collector/inputs/eventlog/WindowsEventlogHandler.java
+++ b/src/main/java/org/graylog/collector/inputs/eventlog/WindowsEventlogHandler.java
@@ -50,7 +50,6 @@ public class WindowsEventlogHandler implements EventLogNotification {
 
         final MessageBuilder builder = messageBuilder
                 .copy()
-                .source(record.getComputerName())
                 .message(isNullOrEmpty(record.getMessage()) ? "empty" : record.getMessage().trim())
                 .timestamp(getDateTime(record.getTimeGenerated()))
                 .level(getMessageLevel(record));

--- a/src/main/java/org/graylog/collector/inputs/eventlog/WindowsEventlogInput.java
+++ b/src/main/java/org/graylog/collector/inputs/eventlog/WindowsEventlogInput.java
@@ -18,6 +18,7 @@ package org.graylog.collector.inputs.eventlog;
 
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.collector.MessageBuilder;
+import org.graylog.collector.annotations.CollectorHostName;
 import org.graylog.collector.buffer.Buffer;
 import org.graylog.collector.config.ConfigurationUtils;
 import org.graylog.collector.file.ChunkReader;
@@ -31,16 +32,19 @@ public class WindowsEventlogInput extends InputService {
     private final WindowsEventlogInputConfiguration configuration;
     private final Buffer buffer;
     private final EventLogThread logThread;
+    private final String collectorHostName;
 
     public interface Factory extends InputService.Factory<WindowsEventlogInput, WindowsEventlogInputConfiguration> {
         WindowsEventlogInput create(WindowsEventlogInputConfiguration configuration);
     }
 
     @Inject
-    public WindowsEventlogInput(@Assisted WindowsEventlogInputConfiguration configuration, Buffer buffer) {
+    public WindowsEventlogInput(@Assisted WindowsEventlogInputConfiguration configuration, Buffer buffer,
+                                @CollectorHostName String collectorHostName) {
         this.configuration = configuration;
         this.buffer = buffer;
         this.logThread = EventLogThread.getInstance(configuration.getSourceName());
+        this.collectorHostName = collectorHostName;
     }
 
     @Override
@@ -48,6 +52,7 @@ public class WindowsEventlogInput extends InputService {
         final MessageBuilder messageBuilder = new MessageBuilder()
                 .input(getId())
                 .outputs(getOutputs())
+                .source(collectorHostName)
                 .fields(configuration.getMessageFields());
 
         logThread.add(new WindowsEventlogHandler(messageBuilder, buffer));

--- a/src/main/java/org/graylog/collector/inputs/file/FileInput.java
+++ b/src/main/java/org/graylog/collector/inputs/file/FileInput.java
@@ -18,6 +18,7 @@ package org.graylog.collector.inputs.file;
 
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.collector.MessageBuilder;
+import org.graylog.collector.annotations.CollectorHostName;
 import org.graylog.collector.buffer.Buffer;
 import org.graylog.collector.config.ConfigurationUtils;
 import org.graylog.collector.file.ChunkReader;
@@ -25,7 +26,6 @@ import org.graylog.collector.file.FileObserver;
 import org.graylog.collector.file.FileReaderService;
 import org.graylog.collector.file.PathSet;
 import org.graylog.collector.inputs.InputService;
-import org.graylog.collector.utils.Utils;
 
 import javax.inject.Inject;
 import java.util.Set;
@@ -43,13 +43,16 @@ public class FileInput extends InputService {
     private final FileInputConfiguration configuration;
     private final Buffer buffer;
     private final FileObserver fileObserver;
+    private final String collectorHostName;
     private FileReaderService readerService;
 
     @Inject
-    public FileInput(@Assisted FileInputConfiguration inputConfiguration, Buffer buffer, FileObserver fileObserver) {
+    public FileInput(@Assisted FileInputConfiguration inputConfiguration, Buffer buffer, FileObserver fileObserver,
+                     @CollectorHostName String collectorHostName) {
         this.configuration = inputConfiguration;
         this.buffer = buffer;
         this.fileObserver = fileObserver;
+        this.collectorHostName = collectorHostName;
     }
 
     @Override
@@ -68,7 +71,7 @@ public class FileInput extends InputService {
         final MessageBuilder messageBuilder = new MessageBuilder()
                 .input(getId())
                 .outputs(getOutputs())
-                .source(Utils.getHostname())
+                .source(collectorHostName)
                 .fields(configuration.getMessageFields());
         final PathSet pathSet = configuration.getPathSet();
         readerService = new FileReaderService(

--- a/src/main/java/org/graylog/collector/utils/CollectorHostNameConfiguration.java
+++ b/src/main/java/org/graylog/collector/utils/CollectorHostNameConfiguration.java
@@ -16,12 +16,23 @@
  */
 package org.graylog.collector.utils;
 
-import java.util.Locale;
+import com.typesafe.config.Config;
 
-public class Utils {
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.US).startsWith("windows");
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 
-    public static boolean isWindows() {
-        return IS_WINDOWS;
+public class CollectorHostNameConfiguration {
+    private static final String CONFIG_PATH = "host-name";
+    private final String hostName;
+
+    @Inject
+    public CollectorHostNameConfiguration(Config config) {
+        this.hostName = config.hasPath(CONFIG_PATH) ? config.getString(CONFIG_PATH) : null;
+    }
+
+    @Nullable
+    public String getHostName() {
+        return hostName;
     }
 }
+

--- a/src/main/java/org/graylog/collector/utils/CollectorHostNameModule.java
+++ b/src/main/java/org/graylog/collector/utils/CollectorHostNameModule.java
@@ -16,12 +16,13 @@
  */
 package org.graylog.collector.utils;
 
-import java.util.Locale;
+import org.graylog.collector.annotations.CollectorHostName;
+import org.graylog.collector.guice.CollectorModule;
 
-public class Utils {
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.US).startsWith("windows");
-
-    public static boolean isWindows() {
-        return IS_WINDOWS;
+public class CollectorHostNameModule extends CollectorModule {
+    @Override
+    protected void configure() {
+        bind(CollectorHostNameConfiguration.class);
+        bind(String.class).annotatedWith(CollectorHostName.class).toProvider(CollectorHostNameProvider.class);
     }
 }

--- a/src/main/java/org/graylog/collector/utils/CollectorHostNameProvider.java
+++ b/src/main/java/org/graylog/collector/utils/CollectorHostNameProvider.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+public class CollectorHostNameProvider implements Provider<String> {
+    private final Supplier<String> hostName;
+
+    @Inject
+    public CollectorHostNameProvider(CollectorHostNameConfiguration config, CollectorId collectorId) {
+        this(new CollectorHostNameSupplier(config.getHostName(), collectorId));
+    }
+
+    @VisibleForTesting
+    protected CollectorHostNameProvider(CollectorHostNameSupplier supplier) {
+        this.hostName = Suppliers.memoize(supplier);
+    }
+
+    @Override
+    public String get() {
+        return hostName.get();
+    }
+}

--- a/src/main/java/org/graylog/collector/utils/CollectorHostNameSupplier.java
+++ b/src/main/java/org/graylog/collector/utils/CollectorHostNameSupplier.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.utils;
+
+import com.google.common.base.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static java.util.Objects.requireNonNull;
+
+public class CollectorHostNameSupplier implements Supplier<String> {
+    private static final Logger LOG = LoggerFactory.getLogger(CollectorHostNameSupplier.class);
+
+    private final String defaultHostName;
+    private final CollectorId collectorId;
+
+    public CollectorHostNameSupplier(@Nullable String defaultHostName, CollectorId collectorId) {
+        this.defaultHostName = defaultHostName;
+        this.collectorId = requireNonNull(collectorId);
+    }
+
+    @Override
+    public String get() {
+        return defaultHostName == null ? detectHostname() : defaultHostName;
+    }
+
+    private String detectHostname() {
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            hostname = System.getenv("HOSTNAME");
+            if (hostname == null) {
+                hostname = System.getenv("COMPUTERNAME");
+            }
+            if (hostname == null) {
+                hostname = "unknown-" + collectorId.toString();
+                LOG.warn("Unable to detect the local host name, falling back to \"{}\". "
+                        + "Use the \"host-name\" configuration setting to override.", hostname);
+            }
+        }
+
+        return hostname;
+    }
+}

--- a/src/test/java/org/graylog/collector/inputs/eventlog/WindowsEventlogHandlerTest.java
+++ b/src/test/java/org/graylog/collector/inputs/eventlog/WindowsEventlogHandlerTest.java
@@ -74,6 +74,7 @@ public class WindowsEventlogHandlerTest {
 
         messageBuilder.input("input-id");
         messageBuilder.outputs(Sets.newHashSet("output-id"));
+        messageBuilder.source("foobar.example.net");
 
         return messageBuilder;
     }
@@ -109,7 +110,7 @@ public class WindowsEventlogHandlerTest {
         final Message message = buffer.getMessages().get(0);
 
         assertEquals("The log message", message.getMessage());
-        assertEquals("IE10Win7", message.getSource());
+        assertEquals("foobar.example.net", message.getSource());
         assertEquals(Message.Level.INFO, message.getLevel());
         assertEquals(new DateTime(0L).withZone(DateTimeZone.UTC), message.getTimestamp());
 

--- a/src/test/java/org/graylog/collector/utils/CollectorHostNameConfigurationTest.java
+++ b/src/test/java/org/graylog/collector/utils/CollectorHostNameConfigurationTest.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.utils;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class CollectorHostNameConfigurationTest {
+    @Test
+    public void getHostNameReturnsNullIfHostNameNotOverridden() {
+        final Config config = ConfigFactory.empty();
+        final CollectorHostNameConfiguration hostNameConfiguration = new CollectorHostNameConfiguration(config);
+        assertNull(hostNameConfiguration.getHostName());
+    }
+
+    @Test
+    public void getHostNameReturnsHostNameIfHostNameOverridden() {
+        final Config config = ConfigFactory.parseMap(Collections.singletonMap("host-name", "foobar.example.net"));
+        final CollectorHostNameConfiguration hostNameConfiguration = new CollectorHostNameConfiguration(config);
+        assertEquals("foobar.example.net", hostNameConfiguration.getHostName());
+    }
+}

--- a/src/test/java/org/graylog/collector/utils/CollectorHostNameProviderTest.java
+++ b/src/test/java/org/graylog/collector/utils/CollectorHostNameProviderTest.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CollectorHostNameProviderTest {
+    @Test
+    public void providerMemoizesHostName() throws Exception {
+        final CollectorHostNameSupplier supplier = mock(CollectorHostNameSupplier.class);
+        when(supplier.get()).thenReturn("foobar.example.net");
+
+        final CollectorHostNameProvider provider = new CollectorHostNameProvider(supplier);
+
+        assertEquals("foobar.example.net", provider.get());
+        assertEquals("foobar.example.net", provider.get());
+        verify(supplier, only()).get();
+    }
+}

--- a/src/test/java/org/graylog/collector/utils/CollectorHostNameSupplierTest.java
+++ b/src/test/java/org/graylog/collector/utils/CollectorHostNameSupplierTest.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CollectorHostNameSupplierTest {
+    @Mock
+    public CollectorId collectorId;
+
+    @Before
+    public void setUp() throws Exception {
+        when(collectorId.toString()).thenReturn("cafebabedeadbeef");
+    }
+
+    @Test
+    public void getReturnsDefaultHostName() throws Exception {
+        final CollectorHostNameSupplier supplier = new CollectorHostNameSupplier("foobar.example.net", collectorId);
+        assertEquals("foobar.example.net", supplier.get());
+    }
+
+    @Test
+    public void getDetectsHostNameIfDefaultIsMissing() throws Exception {
+        final CollectorHostNameSupplier supplier = new CollectorHostNameSupplier(null, collectorId);
+        final String hostName = supplier.get();
+        assertNotNull(hostName);
+    }
+}


### PR DESCRIPTION
For the sake of consistency the Windows Eventlog input now uses the canonical host name of the Graylog Collector as "source" field in the GELF messages it's generating. The original "Computer Name" from the Windows Eventlog can still be accessed via the "event_computer_name" message field.

Fixes #68 (and depends on #71)
