### PR TITLE
Update URL for Graylog Collector registration

### DIFF
--- a/src/main/java/org/graylog/collector/heartbeat/CollectorRegistrationService.java
+++ b/src/main/java/org/graylog/collector/heartbeat/CollectorRegistrationService.java
@@ -22,6 +22,6 @@ import retrofit.http.PUT;
 import retrofit.http.Path;
 
 public interface CollectorRegistrationService {
-    @PUT("/system/collectors/{collectorId}")
+    @PUT("/plugins/org.graylog.plugins.collector/collectors/{collectorId}")
     Response register(@Path("collectorId") String collectorId, @Body CollectorRegistrationRequest request);
 }


### PR DESCRIPTION
This PR updates the request path for registering a Graylog Collector at a Graylog server node after the functionality has been moved into a plugin (https://github.com/Graylog2/graylog-plugin-collector) in Graylog 2.0.0-alpha.5.

Changing the URL also means that the Graylog Collector won't work with old versions of Graylog anymore.

Fixes #84
