### PR TITLE
Support IBM_JDK

### DIFF
--- a/src/main/scripts/graylog-collector-service.bat
+++ b/src/main/scripts/graylog-collector-service.bat
@@ -33,7 +33,7 @@ SET SERVICE_NAME=%1
 FOR %%D in ("%COLLECTOR_BIN_DIR%..") DO SET COLLECTOR_ROOT=%%~dpfD
 
 :: Detect if we are running on 32bit or 64bit Windows.
-"%JAVA_HOME%\bin\java" -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
+"%JAVA_HOME%\bin\java.exe" -d32 -version 2>&1 | "%windir%\System32\find" "does not support" >nul:
 IF errorlevel 1 (SET ARCH=x86) ELSE (SET ARCH=x64)
 
 :: Use the correct executable based on the architecture.
@@ -65,6 +65,8 @@ ECHO ARCH:         "%ARCH%"
 ECHO.
 
 :: Select the correct JVM DLL.
+SET JVM_DLL=%JAVA_HOME%\jre\bin\default\jvm.dll
+IF EXIST "%JVM_DLL%" GOTO actionInstall
 SET JVM_DLL=%JAVA_HOME%\jre\bin\server\jvm.dll
 IF EXIST "%JVM_DLL%" GOTO actionInstall
 SET JVM_DLL=%JAVA_HOME%\bin\server\jvm.dll


### PR DESCRIPTION
The service would not start correctly because a 64-bit jvm.dll was being passed to a 32-bit service as IBM JDK's output of java -version is not the same as Oracle's.
- Have a cross-platform check for 32-bit or 64-bit.
- Include IBM_JDK's default location for the jvm.dll.
